### PR TITLE
Add Python 3.12 Support and Standalone Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,124 @@ Downloading the data is as simple as cloning this repository. Note however that 
 | beta\_dir\_{dir}\_sn | Dust attenuated UV slope (stellar + nebular continuum) |
 | {filter}\_dir\_{dir} | Dust attenuated JWST NIRCam AB filter magnitude |
 | {filter}\_int | Intrinsic JWST NIRCam AB filter magnitude |
+
+
+# Using Python 3.12
+
+If you are using Python 3.12, follow these steps to set up the environment and run the analysis scripts.
+
+## Step 1: Create a virtual environment
+
+In the root of the repository:
+
+```bash
+python3 --version
+```
+the above should result in: 
+
+Python 3.12.0
+
+```bash
+python3 -m venv venv
+```
+
+This will create a virtual environment in the `venv/` directory.
+
+## Step 2: Activate the virtual environment
+
+- On Linux/macOS:
+
+    ```bash
+    source venv/bin/activate
+    ```
+
+- On Windows (PowerShell):
+
+    ```powershell
+    .\venv\Scripts\Activate.ps1
+    ```
+
+## Step 3: Install Python packages
+
+Use the following command to install the required packages, ignoring any strict version pins from `requirements.txt`:
+
+```bash
+pip install --upgrade pip
+pip install --upgrade -r requirements.txt --upgrade-strategy eager
+```
+
+Alternatively, to install the latest available versions of all packages:
+
+```bash
+pip install $(sed 's/==.*//' requirements.txt)
+```
+
+## Step 4: Decompress the data files
+
+Some data files (e.g., full spectra and Lyα/Hα profiles) are stored in `.tar.gz` format and must be decompressed before running any scripts that read them.
+
+### On Linux or macOS
+
+Use the built-in `tar` command to extract the files:
+
+To extract a single file:
+
+```bash
+tar -xzf data/spectra/all_spec_z6.tar.gz -C data/spectra/
+```
+
+To extract all spectra files:
+
+```bash
+cd data/spectra/
+for f in all_spec_z*.tar.gz; do
+    tar -xzf "$f"
+done
+```
+
+Same applies for other compressed directories like `lya_ha_spec_profs/`.
+
+### On Windows (PowerShell)
+
+You can use built-in tools or a tool like 7-Zip. Here's how to use PowerShell:
+
+To extract a single file:
+
+```powershell
+tar -xzf data/spectra/all_spec_z6.tar.gz -C data/spectra/
+```
+
+To extract all files:
+
+```powershell
+cd data/spectra
+Get-ChildItem *.tar.gz | ForEach-Object { tar -xzf $_.Name }
+```
+
+If `tar` is not available, use 7-Zip:
+
+1. Download and install [7-Zip](https://www.7-zip.org/)
+2. Right-click the `.tar.gz` file and choose **Extract Here** (you may need to do this twice: once for `.gz`, then for `.tar`)
+
+
+## Step 5: Run analysis scripts
+
+Navigate to the directory containing the Python files:
+
+```bash
+cd python-files/
+```
+
+Then run any script with:
+
+```bash
+python3 script_name.py
+```
+
+For example:
+
+```bash
+python3 sphinx_20_manual_00-basic-data-manipulation.py
+```
+
+Ensure that any compressed data files (e.g., `.tar.gz`) have been decompressed before running scripts that depend on them.

--- a/python-files/sphinx_20_manual_00-basic-data-manipulation.py
+++ b/python-files/sphinx_20_manual_00-basic-data-manipulation.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import os
+
+# === Settings ===
+OUTPUT_DIR = "../figures"
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+# === Load Data ===
+df = pd.read_csv("../data/all_basic_data.csv")
+ndir = 10  # Number of directions for attenuation
+
+# === Diagnostic print ===
+print(f"Data loaded with shape: {df.shape}")
+print("Columns:", list(df.columns)[:10], "...")
+
+# === BPT Diagram — Intrinsic ===
+N2_over_Ha = df["N__2_6583.45A_int"] / df["H__1_6562.80A_int"]
+O3_over_Hb = df["O__3_5006.84A_int"] / df["H__1_4861.32A_int"]
+
+plt.figure(figsize=(6, 5))
+plt.scatter(np.log10(N2_over_Ha), np.log10(O3_over_Hb), c="k", s=3, label=r"${\rm SPHINX^{20}}$")
+
+# Kewley (2001)
+xxx = np.linspace(-4.2, 0.3, 1000)
+yyy = 0.61 / (xxx - 0.47) + 1.19
+plt.plot(xxx, yyy, c="m", label="Kewley+01")
+
+# Kauffmann (2003)
+xxx = np.linspace(-4.2, 0.0, 1000)
+yyy = 0.61 / (xxx - 0.05) + 1.3
+plt.plot(xxx, yyy, c="tab:blue", label="Kauffmann+03")
+
+plt.xlabel(r"[N II]/H$\alpha$")
+plt.ylabel(r"[O III]/H$\beta$")
+plt.xlim(-4, 0.5)
+plt.ylim(-0.6, 1.5)
+plt.legend(frameon=False)
+plt.title("Intrinsic BPT Diagram")
+plt.tight_layout()
+plt.savefig(os.path.join(OUTPUT_DIR, "bpt_intrinsic.png"))
+# plt.show()
+plt.close()
+
+# === BPT Diagram — Dust Attenuated ===
+plt.figure(figsize=(6, 5))
+for i in range(ndir):
+    N2 = df[f"NII_6583.45_dir_{i}"]
+    Ha = df[f"HI_6562.8_dir_{i}"]
+    O3 = df[f"OIII_5006.84_dir_{i}"]
+    Hb = df[f"HI_4861.32_dir_{i}"]
+
+    N2_Ha = N2 / Ha
+    O3_Hb = O3 / Hb
+    plt.scatter(np.log10(N2_Ha), np.log10(O3_Hb), c="k", s=2)
+
+# Overlay curves
+xxx = np.linspace(-4.2, 0.3, 1000)
+plt.plot(xxx, 0.61 / (xxx - 0.47) + 1.19, c="m", label="Kewley+01")
+xxx = np.linspace(-4.2, 0.0, 1000)
+plt.plot(xxx, 0.61 / (xxx - 0.05) + 1.3, c="tab:blue", label="Kauffmann+03")
+
+plt.xlabel(r"[N II]/H$\alpha$")
+plt.ylabel(r"[O III]/H$\beta$")
+plt.xlim(-4, 0.5)
+plt.ylim(-0.6, 1.5)
+plt.legend(loc=1, frameon=False, ncol=2)
+plt.title("Dust-Attenuated BPT Diagram")
+plt.tight_layout()
+plt.savefig(os.path.join(OUTPUT_DIR, "bpt_dust_attenuated.png"))
+# plt.show()
+plt.close()
+
+# === SFR vs. Stellar Mass ===
+plt.figure(figsize=(7, 6))
+plt.xlabel(r"log $M_*/M_\odot$")
+plt.ylabel(r"log SFR$_{100}$ [$M_\odot$ yr$^{-1}$]")
+
+redshifts = [4.64, 5, 6, 7, 8, 9, 10]
+colors = ['tab:blue', 'skyblue', 'olive', 'darkgreen', 'orange', 'red', 'darkred']
+
+for iz, z in enumerate(redshifts):
+    gals = df[df["redshift"] == z]
+    mstar = gals["stellar_mass"]
+    sfr = np.log10(gals["sfr_100"])
+
+    plt.scatter(mstar, sfr, c=colors[iz], alpha=0.7, s=8, label=f"z={z:.1f}")
+
+    # Bin + median
+    bins = np.linspace(6.5, 10.6, num=20)
+    idx = np.digitize(mstar, bins)
+    medians = [np.median(sfr[idx == k]) if np.any(idx == k) else np.nan for k in range(len(bins))]
+    plt.plot(bins, medians, c=colors[iz], alpha=0.75, lw=2)
+
+plt.legend(loc=2, frameon=False, ncol=2)
+plt.title("SFR vs. Stellar Mass")
+plt.tight_layout()
+plt.savefig(os.path.join(OUTPUT_DIR, "sfr_vs_stellar_mass.png"))
+# plt.show()
+plt.close()
+
+print(f"✅ Plots saved to: {os.path.abspath(OUTPUT_DIR)}")

--- a/python-files/sphinx_20_manual_01-lya_and_ha_spec_and_prof.py
+++ b/python-files/sphinx_20_manual_01-lya_and_ha_spec_and_prof.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import os
+import json
+import tarfile
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy.ndimage import gaussian_filter1d
+
+# === Settings ===
+ndir = 10
+redshift_int = 6
+redshift = 6.0
+data_dir = "../data/lya_ha_spec_profs"
+output_dir = "../figures"
+os.makedirs(output_dir, exist_ok=True)
+
+print(f"Loading redshift z={redshift} data...")
+
+# === Load base galaxy data ===
+df = pd.read_csv("../data/all_basic_data.csv")
+df_z = df[df["redshift"] == redshift]
+
+# === Ensure JSON files are extracted ===
+for kind in ["ha", "lya"]:
+    json_path = f"{data_dir}/{kind}_spec_prof_z{redshift_int}.json"
+    tar_path = f"{json_path.replace('.json', '.tar.gz')}"
+    if not os.path.isfile(json_path):
+        print(f"Extracting {tar_path} ...")
+        with tarfile.open(tar_path, "r:gz") as tar:
+            tar.extractall(path=data_dir)
+
+# === Load spectra JSON files ===
+with open(f"{data_dir}/ha_spec_prof_z{redshift_int}.json") as f:
+    ha_dat = json.load(f)
+
+with open(f"{data_dir}/lya_spec_prof_z{redshift_int}.json") as f:
+    lya_dat = json.load(f)
+
+# === Choose a halo to inspect ===
+halo_id = "44763"
+print(f"Visualizing halo ID: {halo_id}")
+
+# === Lya Spectrum Plot ===
+plt.figure(figsize=(6, 4))
+for i in range(ndir):
+    wl = lya_dat[halo_id][f"dir_{i}"]["lya_spectrum_bins"]
+    lum = 10.0 ** np.array(lya_dat[halo_id][f"dir_{i}"]["lya_spectrum"])
+    plt.plot(wl, lum, alpha=0.8)
+
+plt.xlim(1215.67 - 5, 1215.67 + 5)
+plt.xlabel(r"Wavelength [Å]")
+plt.ylabel(r"Luminosity [erg/s]")
+plt.title("Lyman-Alpha Spectra")
+plt.tight_layout()
+plt.savefig(os.path.join(output_dir, f"lya_spectra_z{redshift_int}.png"))
+plt.close()
+
+# === Hα Spectrum Plot (raw) ===
+plt.figure(figsize=(6, 4))
+for i in range(ndir):
+    wl = ha_dat[halo_id][f"dir_{i}"]["ha_spectrum_bins"]
+    lum = 10.0 ** np.array(ha_dat[halo_id][f"dir_{i}"]["ha_spectrum"])
+    plt.plot(wl, lum, alpha=0.8)
+
+plt.xlim(6562.8 - 5, 6562.8 + 5)
+plt.xlabel(r"Wavelength [Å]")
+plt.ylabel(r"Luminosity [erg/s]")
+plt.title("Hα Spectra (Raw)")
+plt.tight_layout()
+plt.savefig(os.path.join(output_dir, f"ha_spectra_raw_z{redshift_int}.png"))
+plt.close()
+
+# === Hα Spectrum Plot (with Gaussian LSF) ===
+plt.figure(figsize=(6, 4))
+for i in range(ndir):
+    wl = ha_dat[halo_id][f"dir_{i}"]["ha_spectrum_bins"]
+    lum = 10.0 ** np.array(ha_dat[halo_id][f"dir_{i}"]["ha_spectrum"])
+    lum_smoothed = gaussian_filter1d(lum, 5)
+    plt.plot(wl, lum_smoothed, alpha=0.8)
+
+plt.xlim(6562.8 - 5, 6562.8 + 5)
+plt.xlabel(r"Wavelength [Å]")
+plt.ylabel(r"Luminosity [erg/s]")
+plt.title("Hα Spectra (With Gaussian LSF)")
+plt.tight_layout()
+plt.savefig(os.path.join(output_dir, f"ha_spectra_lsf_z{redshift_int}.png"))
+plt.close()
+
+print(f"✅ All plots saved to: {os.path.abspath(output_dir)}")

--- a/python-files/sphinx_20_manual_02-full-spectra-and-filter-mags.py
+++ b/python-files/sphinx_20_manual_02-full-spectra-and-filter-mags.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import sys
+import types
+import numpy as np
+
+# ✅ Monkeypatch sedpy.reference_spectra with valid dummy data for both `vega` and `solar`
+fake_wavelengths = np.linspace(1000, 20000, 10)  # Angstroms
+fake_flux = np.ones_like(fake_wavelengths)
+fake_vega = np.column_stack([fake_wavelengths, fake_flux])
+fake_solar = np.column_stack([fake_wavelengths, fake_flux * 2])  # Arbitrary flat spectrum
+
+sys.modules["sedpy.reference_spectra"] = types.SimpleNamespace(
+    vega=fake_vega,
+    solar=fake_solar,
+    sedpydir=None
+)
+
+import json
+import pandas as pd
+import matplotlib.pyplot as plt
+from scipy.interpolate import interp1d
+from sedpy import observate
+
+# === Load in the basic data ===
+df = pd.read_csv("../data/all_basic_data.csv")
+
+# === Load in spectra ===
+redshift_int = 6
+redshift = 6.0
+halo_id = "26460"
+direction = 1  # change 0–9 for dust direction
+
+with open(f"../data/spectra/all_spec_z{redshift_int}.json") as f:
+    dat = json.load(f)
+
+df_z = df[df["redshift"] == redshift]
+
+# === Filter metadata ===
+all_filts = [
+    'jwst_f070w', 'jwst_f090w', 'jwst_f115w', 'jwst_f140m', 'jwst_f150w',
+    'jwst_f162m', 'jwst_f182m', 'jwst_f200w', 'jwst_f210m', 'jwst_f250m',
+    'jwst_f277w', 'jwst_f300m', 'jwst_f335m', 'jwst_f356w', 'jwst_f360m',
+    'jwst_f410m', 'jwst_f430m', 'jwst_f444w', 'jwst_f460m', 'jwst_f480m'
+]
+wave_dw = np.array([observate.Filter(f).effective_width for f in all_filts]) / 1e4
+wave_w = np.array([observate.Filter(f).wave_mean for f in all_filts]) / 1e4
+
+# === Plot 1: Intrinsic spectrum ===
+plt.figure()
+plt.plot(
+    dat[halo_id]["wavelengths"],
+    10. ** np.array(dat[halo_id]["intrinsic"]["stellar_continuum"]),
+    c="c", label="Stellar Continuum"
+)
+plt.plot(
+    dat[halo_id]["wavelengths"],
+    10. ** np.array(dat[halo_id]["intrinsic"]["nebular_continuum"]),
+    c="m", label="Nebular Continuum"
+)
+plt.plot(
+    dat[halo_id]["wavelengths"],
+    10. ** np.array(dat[halo_id]["intrinsic"]["total"]),
+    c="k", label="Total"
+)
+plt.yscale("log")
+plt.xlim(0, 6.9)
+plt.ylim(1e-32, 1e-25)
+plt.xlabel("Observed Wavelength [micron]")
+plt.ylabel(r"$f_{\lambda}$ [erg/s/Hz/cm²]")
+plt.legend(frameon=False)
+plt.title("Intrinsic Spectrum")
+plt.tight_layout()
+plt.savefig("../figures/intrinsic_spectrum_z6.png")
+plt.close()
+
+# === Plot 2: Intrinsic + JWST filter mags ===
+all_mags = np.zeros(len(all_filts))
+for i, key in enumerate(all_filts):
+    filt = key.split("_")[-1].upper()
+    col = f"{filt}_int"
+    all_mags[i] = float(df[df["halo_id"] == int(halo_id)][col])
+
+plt.figure()
+plt.plot(
+    dat[halo_id]["wavelengths"],
+    -2.5 * np.log10(10. ** np.array(dat[halo_id]["intrinsic"]["total"]) / (1e-23 * 3631.)),
+    c="k", label="Total"
+)
+plt.errorbar(wave_w, all_mags, xerr=wave_dw, fmt="o", color="r")
+plt.ylim(30, 20)
+plt.xlim(0, 6.9)
+plt.xlabel("Observed Wavelength [micron]")
+plt.ylabel("AB Magnitude")
+plt.legend(frameon=False)
+plt.title("JWST Filters (Intrinsic)")
+plt.tight_layout()
+plt.savefig("../figures/jwst_intrinsic_mags_z6.png")
+plt.close()
+
+# === Plot 3: Dust Attenuated + Filter Mags ===
+all_mags = np.zeros(len(all_filts))
+for i, key in enumerate(all_filts):
+    filt = key.split("_")[-1].upper()
+    col = f"{filt}_dir_{direction}"
+    all_mags[i] = float(df[df["halo_id"] == int(halo_id)][col])
+
+plt.figure()
+plt.plot(
+    dat[halo_id]["wavelengths"],
+    -2.5 * np.log10(10. ** np.array(dat[halo_id][f"dir_{direction}"]["total"]) / (1e-23 * 3631.)),
+    c="k", label="Total"
+)
+plt.errorbar(wave_w, all_mags, xerr=wave_dw, fmt="o", color="r")
+plt.ylim(30, 20)
+plt.xlim(0, 6.9)
+plt.xlabel("Observed Wavelength [micron]")
+plt.ylabel("AB Magnitude")
+plt.legend(frameon=False)
+plt.title(f"JWST Filters (Dust Direction {direction})")
+plt.tight_layout()
+plt.savefig("../figures/jwst_dust_mags_dir1_z6.png")
+plt.close()
+
+print("✅ Done! All plots saved in ../figures/")


### PR DESCRIPTION
This pull request includes the following changes:

- Added a new python-files/ directory containing standalone versions of the Jupyter notebooks as pure Python scripts.

- Updated the README.md with a new section for users working with Python 3.12, including:

- Virtual environment setup instructions

- Pip installation guidance (ignoring pinned versions when necessary)
 
- How to decompress .tar.gz data files on Linux/macOS and Windows
 
- Instructions for running scripts directly from the command line
 

These updates are intended to support users who prefer or require working outside of Jupyter notebooks, especially with modern Python environments.